### PR TITLE
Problem in the background image of landing page

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,7 +69,13 @@
     background: url("images/Desktop\ -\ 1.jpg") no-repeat center;
     color: whitesmoke;
     min-height: 500px;
+    background-size: cover;
     font-family: 'Ubuntu', sans-serif;
+}
+@media screen and (min-width:450px){
+    .home{
+        background-position: top right;
+    }
 }
 
 .home .max-width{


### PR DESCRIPTION
I tried fixing the background image of your landing page. The problem was that, when the screen width would be more, there were white spaces created as the background size was not equal to the division, so I fixed that by adding "background-size: cover". The second problem was that, when my screen width was small, your face was hidden. So I fixed this by adding "background-position: top right". What this will do is, the background image's anchor point will the top right corner. This will help you in showing your face, which is on the right side, even if you decrease the screen's width. And I have used a media query so that in screens below 450px, your face won't be shown and the light trail background will be visible

Your build: 
![image](https://user-images.githubusercontent.com/42411311/110914792-47ba6980-8330-11eb-90e6-0826a70b93e8.png)
![image](https://user-images.githubusercontent.com/42411311/110914813-4e48e100-8330-11eb-9a50-2ffdfdfd0c87.png)

Changed code:
![image](https://user-images.githubusercontent.com/42411311/110914949-7f291600-8330-11eb-90a0-9a7bdbbd7d57.png)
![image](https://user-images.githubusercontent.com/42411311/110914980-8819e780-8330-11eb-9985-ceaad7df155e.png)
![image](https://user-images.githubusercontent.com/42411311/110915776-83a1fe80-8331-11eb-8202-afbe45d8e0e5.png)
below 450px width: 
![image](https://user-images.githubusercontent.com/42411311/110915824-93b9de00-8331-11eb-80f4-fa548cae6a40.png)

I hope you'll find this useful!